### PR TITLE
raise credentials dialog only sometimes

### DIFF
--- a/@UnitTest/exportData.m
+++ b/@UnitTest/exportData.m
@@ -43,7 +43,15 @@ function toRemoteDataToolbox(obj, dataFileName, runData)
     end
     tempFile = fullfile(tempFolder(), [artifactId '.mat']);
     save(tempFile, '-struct', 'runData');
-    client.credentialsDialog();
+    
+    % might need a password to write to repo
+    %   if credentials look complete, don't raise a dialog
+    %   also allow guest user to temporarily "un-guest" with dialog
+    if isempty(client.configuration.password) ...
+            && ~isempty(client.configuration.username)
+        client.credentialsDialog();
+    end
+    
     client.publishArtifact(tempFile, ...
         'artifactId', artifactId, ...
         'version', version);


### PR DESCRIPTION
When writing new data with RemoteDataToolbox, we were always raising a dialog to ask for credentials.  This was unnecessary in cases where the JSON configuration already contained complete credentials.

New behavior:
- If configuration contains complete credentials, don't raise the dialog.
- Still raise the dialog for the "guest" user, to allow temporary "un-guesting" during the write.Kind of like sudo.
