### PR TITLE
return UnitTest object and explicit status from sessions

### DIFF
--- a/@UnitTest/UnitTest.m
+++ b/@UnitTest/UnitTest.m
@@ -188,7 +188,7 @@ classdef UnitTest < handle
         closeAllNonDataMismatchFigures()
         
         % Executive method to run a validation session
-        runValidationSession(vScriptsList, desiredMode, verbosity);
+        [obj, sessionAborted] = runValidationSession(vScriptsList, desiredMode, verbosity);
         
         % Method to select project-specific preferences 
         usePreferencesForProject(projectName, initMode);

--- a/@UnitTest/runValidationSession.m
+++ b/@UnitTest/runValidationSession.m
@@ -1,4 +1,4 @@
-function runValidationSession(vScriptsList, desiredMode)
+function [UnitTestOBJ, abortValidationSession] = runValidationSession(vScriptsList, desiredMode)
 
     if (nargin == 1)
         fprintf('\nAvailable validation modes:');
@@ -24,24 +24,26 @@ function runValidationSession(vScriptsList, desiredMode)
     end
     
     if (strcmp(desiredMode, 'RUN_TIME_ERRORS_ONLY'))
-        validateRunTimeErrors(vScriptsList);
+        [UnitTestOBJ, abortValidationSession] = validateRunTimeErrors(vScriptsList);
         
     elseif (strcmp(desiredMode, 'FAST'))
-        validateFast(vScriptsList);
+        [UnitTestOBJ, abortValidationSession] = validateFast(vScriptsList);
         
     elseif (strcmp(desiredMode, 'FULL')) || (strcmp(desiredMode, 'FULLONLY'))
-        validateFull(vScriptsList, desiredMode);
+        [UnitTestOBJ, abortValidationSession] = validateFull(vScriptsList, desiredMode);
         
     elseif (strcmp(desiredMode, 'PUBLISH'))
-        validatePublish(vScriptsList);
+        [UnitTestOBJ, abortValidationSession] = validatePublish(vScriptsList);
         
     else
+        UnitTestOBJ = [];
+        abortValidationSession = true;
         fprintf('Invalid selection. Run again.\n');
         return;
     end
 end
 
-function validateRunTimeErrors(vScriptsList)
+function [UnitTestOBJ, abortValidationSession] = validateRunTimeErrors(vScriptsList)
     % Instantiate a @UnitTest object
     UnitTestOBJ = UnitTest();
         
@@ -62,7 +64,7 @@ function validateRunTimeErrors(vScriptsList)
 end
 
 
-function validateFast(vScriptsList)
+function [UnitTestOBJ, abortValidationSession] = validateFast(vScriptsList)
 
     % Instantiate a @UnitTest object
     UnitTestOBJ = UnitTest();   
@@ -84,7 +86,7 @@ function validateFast(vScriptsList)
         
 end
 
-function validateFull(vScriptsList, mode)
+function [UnitTestOBJ, abortValidationSession] = validateFull(vScriptsList, mode)
     
     % Instantiate a @UnitTest object
     UnitTestOBJ = UnitTest();
@@ -107,7 +109,7 @@ function validateFull(vScriptsList, mode)
 end
 
 
-function validatePublish(vScriptsList)
+function [UnitTestOBJ, abortValidationSession] = validatePublish(vScriptsList)
 
     % Instantiate a @UnitTest object
     UnitTestOBJ = UnitTest();

--- a/@UnitTest/validate.m
+++ b/@UnitTest/validate.m
@@ -464,6 +464,8 @@ function abortValidationSession = validate(obj, vScriptsToRunList)
             summaryReportEntry.textIsBold{5} = false;
         end
        
+        summaryReportEntry.fastFailed = strcmp(resultStingFastValidation, 'FAILED');
+        summaryReportEntry.fullFailed = strcmp(resultStingFullValidation, 'FAILED');
         summaryReportEntry.timeLapsed = timeLapsed; 
         obj.summaryReport{numel(obj.summaryReport)+1} = summaryReportEntry;
     end % scriptIndex


### PR DESCRIPTION
Hi @npcottaris ,

This PR returns the UnitTest object from the `runValidationSession()` method.  It also adds boolean fields to the `summaryReport`, indicating if the fast or full validation failed.

Returning this information should allow us to respond to validation results programmatically, as well as by reading the output printed to the command window.  This will be useful for setting up an automated Jenkins server that runs validations and reports the results back to GitHub (which is something @DavidBrainard  and I are working on).

I don't think this change would change the current behavior of `runValidationSession()`.  What do you think?

PS -- I accidentally committed this change to master instead of to this branch.  So then I reverted the change to master, and then re-reverted to create this branch.  Sorry for the messy commits.